### PR TITLE
Fixed incorrect formatting

### DIFF
--- a/workshop/content/500_eks-terraform-workshop/540_IAM/tf-files.md
+++ b/workshop/content/500_eks-terraform-workshop/540_IAM/tf-files.md
@@ -165,7 +165,7 @@ To these two roles, various policies are then defined and later on attached to t
 
 One example of a policy that is defined is shown here:
 
-### aws_iam_role_policy__cluster-ServiceRole__PolicyCloudWatchMetrics.tf
+### aws_iam_role_policy__cluster-ServiceRole__PolicyCloudWatchMetrics.tf
 
 {{%expand "Expand here to see the code" %}}
 ```bash


### PR DESCRIPTION
The header was incorrectly formatted when rendered due to non-breaking space. This change seem to fix it at least in the github MD renderer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
